### PR TITLE
fix: resolve prod deploy CloudFormation resource conflict

### DIFF
--- a/infra/lib/api-stack.ts
+++ b/infra/lib/api-stack.ts
@@ -99,7 +99,7 @@ export class ApiStack extends cdk.Stack {
             );
         }
 
-        const api = new HttpApi(this, 'RaffleApi', {
+        const api = new HttpApi(this, 'RaffleHttpApi', {
             disableExecuteApiEndpoint: true,
             description: 'HTTP API for Raffle Winner Picker application',
             corsPreflight: {


### PR DESCRIPTION
## Problem
The production deployment was failing with:
`ValidationError: Update of resource type is not permitted. The new template modifies resource type of the following resources: [RaffleApiFDE69366]`

## Root Cause  
The recent migration from REST API to HTTP API Gateway in PR #21 changed the CloudFormation resource type, which AWS doesn't allow for in-place updates.

## Solution
Renamed the API resource from `RaffleApi` to `RaffleHttpApi` to force CloudFormation to create a new resource instead of trying to modify the existing one.

## Testing
- ✅ Local CDK compilation successful
- ✅ Build passes
- 🔄 Will test production deployment

Fixes the production deployment issue.